### PR TITLE
Optimize ArrayList memory management

### DIFF
--- a/src/model/arraylist.c
+++ b/src/model/arraylist.c
@@ -13,6 +13,7 @@ void al_init(ArrayList* al, size_t esize) {
   al->cap = INITIAL_CAPACITY;
   al->size = 0;
   al->data = malloc(al->cap * esize);
+  al->esize = esize;
 }
 
 ArrayList* al_new(size_t esize) {

--- a/src/model/arraylist.h
+++ b/src/model/arraylist.h
@@ -16,11 +16,13 @@ void al_free(ArrayList** al);
 void al_free_internal(ArrayList* al);
 void* al_get(ArrayList* al, unsigned int index);
 void al_set(ArrayList* al, unsigned int index, void* new_value);
-bool al_add_at(ArrayList* al, void* e, unsigned int index);
-bool al_add(ArrayList* al, void* e);
-bool al_add_all_at(ArrayList* al, void* es, unsigned int n, unsigned int index);
-bool al_add_all(ArrayList* al, void* es, unsigned int n);
-void* al_remove_at(ArrayList* al, unsigned int index);
-void al_remove_all_at(ArrayList* al, void* buf, unsigned int from, unsigned int to);
+bool al_add_at(ArrayList* al, void* to_add, unsigned int index);
+bool al_add(ArrayList* al, void* to_add);
+bool al_add_all_at(ArrayList* al, void* to_adds, unsigned int n, unsigned int index);
+bool al_add_all(ArrayList* al, void* to_adds, unsigned int n);
+bool al_remove_at(ArrayList* al, unsigned int index);
+bool al_remove_at_save(ArrayList* al, unsigned int index, void* buf);
+bool al_remove_all_at(ArrayList* al, unsigned int from, unsigned int to);
+bool al_remove_all_at_save(ArrayList* al, unsigned int from, unsigned int to, void* buf);
 
 #endif

--- a/src/model/arraylist.h
+++ b/src/model/arraylist.h
@@ -6,22 +6,21 @@
 typedef struct {
   unsigned int cap;
   unsigned int size;
-  void** data;
+  char* data;
+  size_t esize;
 } ArrayList;
 
-void al_init(ArrayList* al);
-ArrayList* al_new(void);
+void al_init(ArrayList* al, size_t esize);
+ArrayList* al_new(size_t esize);
 void al_free(ArrayList** al);
 void al_free_internal(ArrayList* al);
-void al_free_with_cleanup(ArrayList** al, void (*fn)(void* e));
-void al_free_internal_with_cleanup(ArrayList* al, void (*fn)(void* e));
-bool al_add_at_static(ArrayList* al, void* e, size_t esize, unsigned int index);
-bool al_add_static(ArrayList* al, void* e, size_t esize);
+void* al_get(ArrayList* al, unsigned int index);
+void al_set(ArrayList* al, unsigned int index, void* new_value);
 bool al_add_at(ArrayList* al, void* e, unsigned int index);
 bool al_add(ArrayList* al, void* e);
-bool al_add_all_at(ArrayList* al, void** es, unsigned int n, unsigned int index);
-bool al_add_all(ArrayList* al, void** es, unsigned int n);
+bool al_add_all_at(ArrayList* al, void* es, unsigned int n, unsigned int index);
+bool al_add_all(ArrayList* al, void* es, unsigned int n);
 void* al_remove_at(ArrayList* al, unsigned int index);
-void al_remove_all_at(ArrayList* al, void** es, unsigned int from, unsigned int to);
+void al_remove_all_at(ArrayList* al, void* buf, unsigned int from, unsigned int to);
 
 #endif

--- a/src/model/crdt/sequence.c
+++ b/src/model/crdt/sequence.c
@@ -1,3 +1,4 @@
+#include <string.h>
 #include <util/bit.h>
 #include <model/arraylist.h>
 #include "guid.h"
@@ -5,17 +6,19 @@
 
 #define BOUNDARY 10
 
-Element* _new_header() {
-  Element* new = element_new();
-  new->id.depth = 1;
-  new->id.keys = keys_from_tokens(1, 0);
+Element _new_header() {
+  Element new;
+  element_init(&new);
+  new.id.depth = 1;
+  new.id.keys = keys_from_tokens(1, 0);
   return new;
 }
 
-Element* _new_trailer() {
-  Element* new = element_new();
-  new->id.depth = 1;
-  new->id.keys = keys_from_tokens(1, 1);
+Element _new_trailer() {
+  Element new;
+  element_init(&new);
+  new.id.depth = 1;
+  new.id.keys = keys_from_tokens(1, 1);
   return new;
 }
 
@@ -23,10 +26,10 @@ void seq_init(Sequence* s) {
   s->uid = 0;
   s->version = 0;
   al_init(&s->elements, sizeof(Element));
-  Element* header = _new_header();
-  Element* trailer = _new_trailer();
-  al_add(&s->elements, header);
-  al_add(&s->elements, trailer);
+  Element header = _new_header();
+  Element trailer = _new_trailer();
+  al_add(&s->elements, &header);
+  al_add(&s->elements, &trailer);
 }
 
 Sequence* seq_new(void) {
@@ -187,49 +190,76 @@ Element* seq_get_element(Sequence* s, unsigned int index) {
   if (index < 0 || index > seq_size(s)) {
     return NULL;
   }
-  return ((Element**) s->elements.data)[index + 1];
+  return al_get(&s->elements, index + 1);
 }
 
-Element* seq_insert(Sequence* s, void* to_insert, unsigned int index) {
+bool _seq_insert(Sequence* s, void* to_insert, unsigned int index, Element* buf) {
   if (index < 0 || index > seq_size(s)) {
-    return NULL;
+    return false;
   }
   s->version++;
-  // TODO how to handle initialization of new elements?
-  Element* new = element_new();
-  new->value = to_insert;
+  Element new = {
+    .version = s->version,
+    .value = to_insert,
+  };
   // account for header index.
-  seq_gen_guid_at(s, &new->id, index + 1);
-  al_add_at(&s->elements, new, index + 1);
-  return new;
+  seq_gen_guid_at(s, &new.id, index + 1);
+  al_add_at(&s->elements, &new, index + 1);
+  if (buf != NULL) {
+    memcpy(buf, &new, sizeof(Element));
+  }
+  return true;
 }
 
-Element* seq_delete(Sequence* s, unsigned int index) {
+bool seq_insert(Sequence* s, void* to_insert, unsigned int index) {
+  return _seq_insert(s, to_insert, index, NULL);
+}
+
+bool seq_insert_save(Sequence* s, void* to_insert, unsigned int index, Element* buf) {
+  return _seq_insert(s, to_insert, index, buf);
+}
+
+bool _seq_delete(Sequence* s, unsigned int index, Element* buf) {
   if (index < 0 || index > seq_size(s)) {
-    return NULL;
+    return false;
   }
   s->version++;
   // account for header index.
-  return al_remove_at(&s->elements, index + 1);
+  if (buf != NULL) {
+    al_remove_at_save(&s->elements, index + 1, buf);
+  } else {
+    al_remove_at(&s->elements, index + 1);
+  }
+  return true;
 }
 
-void seq_remote_insert(Sequence* s, Element* to_insert) {
+bool seq_delete(Sequence* s, unsigned int index) {
+  return _seq_delete(s, index, NULL);
+}
+
+bool seq_delete_save(Sequence* s, unsigned int index, Element* buf) {
+  return _seq_delete(s, index, buf);
+}
+
+bool seq_remote_insert(Sequence* s, Element* to_insert) {
   unsigned int iindex = seq_iindex_of_element_or_after(s, to_insert);
   Element* e = seq_get_element(s, iindex - 1);
   if (guid_equal(&e->id, &to_insert->id)) {
-    return;
+    return false;
   }
   s->version++;
   al_add_at(&s->elements, to_insert, iindex);
+  return true;
 }
 
-Element* seq_remote_delete(Sequence* s, Element* to_delete) {
+bool seq_remote_delete(Sequence* s, Element* to_delete) {
   unsigned int iindex = seq_iindex_of_element_or_after(s, to_delete);
   Element* e = seq_get_element(s, iindex - 1);
   if (!guid_equal(&e->id, &to_delete->id)) {
-    return NULL;
+    return false;
   }
   s->version++;
-  return al_remove_at(&s->elements, iindex);
+  al_remove_at(&s->elements, iindex);
+  return true;
 }
 

--- a/src/model/crdt/sequence.c
+++ b/src/model/crdt/sequence.c
@@ -6,7 +6,7 @@
 
 #define BOUNDARY 10
 
-Element _new_header() {
+Element _header() {
   Element new;
   element_init(&new);
   new.id.depth = 1;
@@ -14,7 +14,7 @@ Element _new_header() {
   return new;
 }
 
-Element _new_trailer() {
+Element _trailer() {
   Element new;
   element_init(&new);
   new.id.depth = 1;
@@ -26,8 +26,8 @@ void seq_init(Sequence* s) {
   s->uid = 0;
   s->version = 0;
   al_init(&s->elements, sizeof(Element));
-  Element header = _new_header();
-  Element trailer = _new_trailer();
+  Element header = _header();
+  Element trailer = _trailer();
   al_add(&s->elements, &header);
   al_add(&s->elements, &trailer);
 }
@@ -145,7 +145,7 @@ void seq_gen_guid_at(Sequence* s, Guid* buf, unsigned int iindex) {
 }
 
 bool _is_larger_than_max(Sequence* s, Element* target) {
-  Element* last = ((Element**) s->elements.data)[s->elements.size - 1];
+  Element* last = al_get(&s->elements, s->elements.size - 1);
   return guid_compare(&target->id, &last->id) > 0;
 }
 
@@ -168,7 +168,7 @@ unsigned int seq_iindex_of_element_or_after(Sequence* s, Element* target) {
   int compare;
   do {
     i = min_i + (max_i - min_i) / 2;
-    Element* next = ((Element**) s->elements.data)[i];
+    Element* next = al_get(&s->elements, i);
     compare = guid_compare(&next->id, &target->id);
     if (compare == 0 || max_i == min_i) {
       return i;

--- a/src/model/crdt/sequence.h
+++ b/src/model/crdt/sequence.h
@@ -22,10 +22,12 @@ void seq_gen_guid_at(Sequence* s, Guid* buf, unsigned int index);
 unsigned int seq_iindex_of_element_or_after(Sequence* s, Element* e);
 unsigned int seq_size(Sequence* s);
 Element* seq_get_element(Sequence* s, unsigned int index);
-Element* seq_insert(Sequence* s, void* to_insert, unsigned int index);
-Element* seq_delete(Sequence* s, unsigned int index);
-void seq_remote_insert(Sequence* s, Element* to_insert);
-Element* seq_remote_delete(Sequence* s, Element* to_delete);
+bool seq_insert(Sequence* s, void* to_insert, unsigned int index);
+bool seq_insert_save(Sequence* s, void* to_insert, unsigned int index, Element* buf);
+bool seq_delete(Sequence* s, unsigned int index);
+bool seq_delete_save(Sequence* s, unsigned int index, Element* buf);
+bool seq_remote_insert(Sequence* s, Element* to_insert);
+bool seq_remote_delete(Sequence* s, Element* to_delete);
 
 #endif
 

--- a/test/model/arraylist_test.c
+++ b/test/model/arraylist_test.c
@@ -45,7 +45,7 @@ START_TEST(test_al_add_expand) {
   ck_assert_int_eq(al.cap, 32);
   ck_assert_int_eq(al.size, 20);
   for (int i = 0; i < al.size; i++) {
-    int* e = al_get(&al, al.size - 1 - i);
+    int* e = al_get(&al, i);
     ck_assert_int_eq(*e, i);
   }
   al_free_internal(&al);
@@ -130,10 +130,11 @@ START_TEST(test_al_remove_at) {
   int es[10] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
   al_add_all(&al, es, 10);
 
-  int* removed = (int*) al_remove_at(&al, 5);
-  ck_assert_int_eq(*removed, 5);
-  removed = (int*) al_remove_at(&al, 5);
-  ck_assert_int_eq(*removed, 6);
+  int removed;
+  al_remove_at_save(&al, 5, &removed);
+  ck_assert_int_eq(removed, 5);
+  al_remove_at_save(&al, 5, &removed);
+  ck_assert_int_eq(removed, 6);
 
   ck_assert_int_eq(al.cap, 16);
   ck_assert_int_eq(al.size, 8);
@@ -153,7 +154,7 @@ START_TEST(test_al_remove_all_at) {
   al_add_all(&al, es, 10);
 
   int removed[5];
-  al_remove_all_at(&al, removed, 3, 8);
+  al_remove_all_at_save(&al, 3, 8, removed);
 
   int expected_removed[] = { 3, 4, 5, 6, 7 };
   for (int i = 0; i < 5; i++) {
@@ -264,8 +265,9 @@ START_TEST(test_al_remove_at_boundary) {
   int es[10] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
   al_add_all(&al, es, 10);
 
-  int* removed = al_remove_at(&al, 10);
-  ck_assert_ptr_null(removed);
+  int removed = 0;
+  al_remove_at_save(&al, 10, &removed);
+  ck_assert_int_eq(removed, 0);
 
   ck_assert_int_eq(al.cap, 16);
   ck_assert_int_eq(al.size, 10);
@@ -283,8 +285,9 @@ START_TEST(test_al_remove_past_boundary) {
   int es[10] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
   al_add_all(&al, es, 10);
 
-  int* removed = (int*) al_remove_at(&al, 11);
-  ck_assert_ptr_null(removed);
+  int removed = 0;
+  al_remove_at_save(&al, 11, &removed);
+  ck_assert_int_eq(removed, 0);
 
   ck_assert_int_eq(al.cap, 16);
   ck_assert_int_eq(al.size, 10);
@@ -303,7 +306,7 @@ START_TEST(test_al_remove_all_at_boundary) {
   al_add_all(&al, es, 10);
 
   int removed[8] = { 0 };
-  al_remove_all_at(&al, removed, 2, 10);
+  al_remove_all_at_save(&al, 2, 10, removed);
 
   for (int i = 0; i < 8; i++) {
     ck_assert_int_eq(removed[i], 2 + i);
@@ -323,7 +326,7 @@ START_TEST(test_al_remove_all_past_boundary) {
   al_add_all(&al, es, 10);
 
   int removed[5] = { 0 };
-  al_remove_all_at(&al, removed, 3, 11);
+  al_remove_all_at_save(&al, 3, 11, removed);
 
   for (int i = 0; i < 5; i++) {
     ck_assert_int_eq(removed[i], 0);
@@ -344,7 +347,7 @@ START_TEST(test_al_remove_all_at_invalid_from_to) {
   al_add_all(&al, es, 10);
 
   int removed[5] = { 0 };
-  al_remove_all_at(&al, removed, 8, 3);
+  al_remove_all_at_save(&al, 8, 3, removed);
 
   for (int i = 0; i < 5; i++) {
     ck_assert_int_eq(removed[i], 0);

--- a/test/model/arraylist_test.c
+++ b/test/model/arraylist_test.c
@@ -4,14 +4,14 @@
 
 START_TEST(test_al_init) {
   ArrayList al;
-  al_init(&al);
+  al_init(&al, sizeof(int));
   ck_assert_int_eq(al.cap, 16);
   ck_assert_int_eq(al.size, 0);
   al_free_internal(&al);
 } END_TEST
 
 START_TEST(test_al_new) {
-  ArrayList* al = al_new();
+  ArrayList* al = al_new(sizeof(int));
   ck_assert_int_eq(al->cap, 16);
   ck_assert_int_eq(al->size, 0);
   free(al);
@@ -19,52 +19,49 @@ START_TEST(test_al_new) {
 
 START_TEST(test_al_add_at_expand) {
   ArrayList al;
-  al_init(&al);
+  al_init(&al, sizeof(int));
 
   for (int i = 0; i < 20; i++) {
-    al_add_at_static(&al, &i, sizeof(int), 0);
+    al_add_at(&al, &i, 0);
   }
 
   ck_assert_int_eq(al.cap, 32);
   ck_assert_int_eq(al.size, 20);
   for (int i = 0; i < al.size; i++) {
-    ck_assert_int_eq(*((int*) al.data[al.size - 1 - i]), i);
+    int* e = al_get(&al, al.size - 1 - i);
+    ck_assert_int_eq(*e, i);
   }
   al_free_internal(&al);
 } END_TEST
 
 START_TEST(test_al_add_expand) {
   ArrayList al;
-  al_init(&al);
+  al_init(&al, sizeof(int));
 
   for (int i = 0; i < 20; i++) {
-    al_add_static(&al, &i, sizeof(int));
+    al_add(&al, &i);
   }
 
   ck_assert_int_eq(al.cap, 32);
   ck_assert_int_eq(al.size, 20);
   for (int i = 0; i < al.size; i++) {
-    ck_assert_int_eq(*((int*) al.data[i]), i);
+    int* e = al_get(&al, al.size - 1 - i);
+    ck_assert_int_eq(*e, i);
   }
   al_free_internal(&al);
 } END_TEST
 
 START_TEST(test_al_add_all_at_expand) {
   ArrayList al;
-  al_init(&al);
-
+  al_init(&al, sizeof(int));
   for (int i = 0; i < 20; i++) {
-    al_add_static(&al, &i, sizeof(int));
+    al_add(&al, &i);
   }
 
   // insert 20 zeros at index 10.
-  int* es[20];
-  for (int i = 0; i < 20; i++) {
-    int* e = malloc(sizeof(int));
-    *e = 0;
-    es[i] = e;
-  }
-  al_add_all_at(&al, (void**) es, 20, 10);
+  int es[20] = { 0 };
+  al_add_all_at(&al, es, 20, 10);
+
   ck_assert_int_eq(al.cap, 64);
   ck_assert_int_eq(al.size, 40);
   int expected[] = {
@@ -74,24 +71,20 @@ START_TEST(test_al_add_all_at_expand) {
     10, 11, 12, 13, 14, 15, 16, 17, 18, 19  \
   };
   for (int i = 0; i < al.size; i++) {
-    int e = *((int*) al.data[i]);
-    ck_assert_int_eq(e, expected[i]);
+    int* e = al_get(&al, i);
+    ck_assert_int_eq(*e, expected[i]);
   }
   al_free_internal(&al);
 } END_TEST
 
 START_TEST(test_al_add_all_at_empty) {
   ArrayList al;
-  al_init(&al);
+  al_init(&al, sizeof(int));
 
   // insert 20 zeros at index 0.
-  int* es[20];
-  for (int i = 0; i < 20; i++) {
-    int* e = malloc(sizeof(int));
-    *e = 0;
-    es[i] = e;
-  }
-  al_add_all_at(&al, (void**) es, 20, 0);
+  int es[20] = { 0 };
+  al_add_all_at(&al, es, 20, 0);
+
   ck_assert_int_eq(al.cap, 32);
   ck_assert_int_eq(al.size, 20);
   int expected[] = {
@@ -99,28 +92,23 @@ START_TEST(test_al_add_all_at_empty) {
      0,  0,  0,  0,  0,  0,  0,  0,  0,  0  \
   };
   for (int i = 0; i < al.size; i++) {
-    int e = *((int*) al.data[i]);
-    ck_assert_int_eq(e, expected[i]);
+    int* e = al_get(&al, i);
+    ck_assert_int_eq(*e, expected[i]);
   }
   al_free_internal(&al);
 } END_TEST
 
 START_TEST(test_al_add_all_expand) {
   ArrayList al;
-  al_init(&al);
-
+  al_init(&al, sizeof(int));
   for (int i = 0; i < 20; i++) {
-    al_add_static(&al, &i, sizeof(int));
+    al_add(&al, &i);
   }
 
   // insert 20 zeros.
-  int* es[20];
-  for (int i = 0; i < 20; i++) {
-    int* e = malloc(sizeof(int));
-    *e = 0;
-    es[i] = e;
-  }
-  al_add_all(&al, (void**) es, 20);
+  int es[20] = { 0 };
+  al_add_all(&al, es, 20);
+
   ck_assert_int_eq(al.cap, 64);
   ck_assert_int_eq(al.size, 40);
   int expected[] = {
@@ -130,23 +118,17 @@ START_TEST(test_al_add_all_expand) {
      0,  0,  0,  0,  0,  0,  0,  0,  0,  0  \
   };
   for (int i = 0; i < al.size; i++) {
-    int e = *((int*) al.data[i]);
-    ck_assert_int_eq(e, expected[i]);
+    int* e = al_get(&al, i);
+    ck_assert_int_eq(*e, expected[i]);
   }
   al_free_internal(&al);
 } END_TEST
 
 START_TEST(test_al_remove_at) {
   ArrayList al;
-  al_init(&al);
-
-  int* es[10];
-  for (int i = 0; i < 10; i++) {
-    int* e = malloc(sizeof(int));
-    *e = i;
-    es[i] = e;
-  }
-  al_add_all(&al, (void**) es, 10);
+  al_init(&al, sizeof(int));
+  int es[10] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+  al_add_all(&al, es, 10);
 
   int* removed = (int*) al_remove_at(&al, 5);
   ck_assert_int_eq(*removed, 5);
@@ -157,93 +139,84 @@ START_TEST(test_al_remove_at) {
   ck_assert_int_eq(al.size, 8);
   int expected[] = { 0, 1, 2, 3, 4, 7, 8, 9 };
   for (int i = 0; i < al.size; i++) {
-    int e = *((int*) al.data[i]);
-    ck_assert_int_eq(e, expected[i]);
+    int* e = al_get(&al, i);
+    ck_assert_int_eq(*e, expected[i]);
   }
   al_free_internal(&al);
 } END_TEST
 
 START_TEST(test_al_remove_all_at) {
   ArrayList al;
-  al_init(&al);
+  al_init(&al, sizeof(int));
 
-  int* es[10];
-  for (int i = 0; i < 10; i++) {
-    int* e = malloc(sizeof(int));
-    *e = i;
-    es[i] = e;
-  }
-  al_add_all(&al, (void**) es, 10);
+  int es[10] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+  al_add_all(&al, es, 10);
 
-  int* removed[5];
-  al_remove_all_at(&al, (void**) &removed, 3, 8);
+  int removed[5];
+  al_remove_all_at(&al, removed, 3, 8);
 
   int expected_removed[] = { 3, 4, 5, 6, 7 };
   for (int i = 0; i < 5; i++) {
-    ck_assert_int_eq(*removed[i], expected_removed[i]);
+    ck_assert_int_eq(removed[i], expected_removed[i]);
   }
 
   int expected_remaining[] = { 0, 1, 2, 8, 9 };
   for (int i = 0; i < 5; i++) {
-    int e = *((int*) al.data[i]);
-    ck_assert_int_eq(e, expected_remaining[i]);
+    int* e = al_get(&al, i);
+    ck_assert_int_eq(*e, expected_remaining[i]);
   }
   al_free_internal(&al);
 } END_TEST
 
 START_TEST(test_al_add_at_boundary) {
   ArrayList al;
-  al_init(&al);
+  al_init(&al, sizeof(int));
   for (int i = 19; i >= 0; i--) {
-    al_add_at_static(&al, &i, sizeof(int), 0);
+    al_add_at(&al, &i, 0);
   }
 
   int e = 20;
-  bool result = al_add_at_static(&al, &e, sizeof(int), 20);
+  bool result = al_add_at(&al, &e, 20);
 
   ck_assert_int_eq(result, true);
   ck_assert_int_eq(al.cap, 32);
   ck_assert_int_eq(al.size, 21);
   for (int i = 0; i < al.size; i++) {
-    ck_assert_int_eq(*((int*) al.data[i]), i);
+    int* e = al_get(&al, i);
+    ck_assert_int_eq(*e, i);
   }
   al_free_internal(&al);
 } END_TEST
 
 START_TEST(test_al_add_past_boundary) {
   ArrayList al;
-  al_init(&al);
+  al_init(&al, sizeof(int));
   for (int i = 19; i >= 0; i--) {
-    al_add_at_static(&al, &i, sizeof(int), 0);
+    al_add_at(&al, &i, 0);
   }
 
   int e = 20;
-  bool result = al_add_at_static(&al, &e, sizeof(int), 21);
+  bool result = al_add_at(&al, &e, 21);
 
   ck_assert_int_eq(result, false);
   ck_assert_int_eq(al.cap, 32);
   ck_assert_int_eq(al.size, 20);
   for (int i = 0; i < al.size; i++) {
-    ck_assert_int_eq(*((int*) al.data[i]), i);
+    int* e = al_get(&al, i);
+    ck_assert_int_eq(*e, i);
   }
   al_free_internal(&al);
 } END_TEST
 
 START_TEST(test_al_add_all_at_boundary) {
   ArrayList al;
-  al_init(&al);
+  al_init(&al, sizeof(int));
   for (int i = 0; i < 20; i++) {
-    al_add_static(&al, &i, sizeof(int));
+    al_add(&al, &i);
   }
   // insert 20 zeros out of bounds.
-  int* es[20];
-  for (int i = 0; i < 20; i++) {
-    int* e = malloc(sizeof(int));
-    *e = 0;
-    es[i] = e;
-  }
-
-  bool result = al_add_all_at(&al, (void**) es, 20, 20);
+  int es[20] = { 0 };
+  bool result = al_add_all_at(&al, es, 20, 20);
 
   ck_assert_int_eq(result, true);
   ck_assert_int_eq(al.cap, 64);
@@ -255,27 +228,21 @@ START_TEST(test_al_add_all_at_boundary) {
      0,  0,  0,  0,  0,  0,  0,  0,  0,  0, \
   };
   for (int i = 0; i < al.size; i++) {
-    int e = *((int*) al.data[i]);
-    ck_assert_int_eq(e, expected[i]);
+    int* e = al_get(&al, i);
+    ck_assert_int_eq(*e, expected[i]);
   }
   al_free_internal(&al);
 } END_TEST
 
 START_TEST(test_al_add_all_past_boundary) {
   ArrayList al;
-  al_init(&al);
+  al_init(&al, sizeof(int));
   for (int i = 0; i < 20; i++) {
-    al_add_static(&al, &i, sizeof(int));
+    al_add(&al, &i);
   }
   // insert 20 zeros out of bounds.
-  int* es[20];
-  for (int i = 0; i < 20; i++) {
-    int* e = malloc(sizeof(int));
-    *e = 0;
-    es[i] = e;
-  }
-
-  bool result = al_add_all_at(&al, (void**) es, 20, 21);
+  int es[20] = { 0 };
+  bool result = al_add_all_at(&al, es, 20, 21);
 
   ck_assert_int_eq(result, false);
   ck_assert_int_eq(al.cap, 32);
@@ -285,46 +252,36 @@ START_TEST(test_al_add_all_past_boundary) {
     10, 11, 12, 13, 14, 15, 16, 17, 18, 19  \
   };
   for (int i = 0; i < al.size; i++) {
-    int e = *((int*) al.data[i]);
-    ck_assert_int_eq(e, expected[i]);
+    int* e = al_get(&al, i);
+    ck_assert_int_eq(*e, expected[i]);
   }
   al_free_internal(&al);
 } END_TEST
 
 START_TEST(test_al_remove_at_boundary) {
   ArrayList al;
-  al_init(&al);
-  int* es[10];
-  for (int i = 0; i < 10; i++) {
-    int* e = malloc(sizeof(int));
-    *e = i;
-    es[i] = e;
-  }
-  al_add_all(&al, (void**) es, 10);
+  al_init(&al, sizeof(int));
+  int es[10] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+  al_add_all(&al, es, 10);
 
-  int* removed = (int*) al_remove_at(&al, 10);
+  int* removed = al_remove_at(&al, 10);
   ck_assert_ptr_null(removed);
 
   ck_assert_int_eq(al.cap, 16);
   ck_assert_int_eq(al.size, 10);
   int expected[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
   for (int i = 0; i < al.size; i++) {
-    int e = *((int*) al.data[i]);
-    ck_assert_int_eq(e, expected[i]);
+    int* e = al_get(&al, i);
+    ck_assert_int_eq(*e, expected[i]);
   }
   al_free_internal(&al);
 } END_TEST
 
 START_TEST(test_al_remove_past_boundary) {
   ArrayList al;
-  al_init(&al);
-  int* es[10];
-  for (int i = 0; i < 10; i++) {
-    int* e = malloc(sizeof(int));
-    *e = i;
-    es[i] = e;
-  }
-  al_add_all(&al, (void**) es, 10);
+  al_init(&al, sizeof(int));
+  int es[10] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+  al_add_all(&al, es, 10);
 
   int* removed = (int*) al_remove_at(&al, 11);
   ck_assert_ptr_null(removed);
@@ -333,85 +290,69 @@ START_TEST(test_al_remove_past_boundary) {
   ck_assert_int_eq(al.size, 10);
   int expected[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
   for (int i = 0; i < al.size; i++) {
-    int e = *((int*) al.data[i]);
-    ck_assert_int_eq(e, expected[i]);
+    int* e = al_get(&al, i);
+    ck_assert_int_eq(*e, expected[i]);
   }
   al_free_internal(&al);
 } END_TEST
 
 START_TEST(test_al_remove_all_at_boundary) {
   ArrayList al;
-  al_init(&al);
-  int* es[10];
-  for (int i = 0; i < 10; i++) {
-    int* e = malloc(sizeof(int));
-    *e = i;
-    es[i] = e;
-  }
-  al_add_all(&al, (void**) es, 10);
+  al_init(&al, sizeof(int));
+  int es[10] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+  al_add_all(&al, es, 10);
 
-  int* removed[8] = { NULL };
-  al_remove_all_at(&al, (void**) &removed, 2, 10);
+  int removed[8] = { 0 };
+  al_remove_all_at(&al, removed, 2, 10);
 
   for (int i = 0; i < 8; i++) {
-    ck_assert_int_eq(*removed[i], 2 + i);
+    ck_assert_int_eq(removed[i], 2 + i);
   }
   int expected_remaining[] = { 0, 1 };
   for (int i = 0; i < 2; i++) {
-    int e = *((int*) al.data[i]);
-    ck_assert_int_eq(e, expected_remaining[i]);
+    int* e = al_get(&al, i);
+    ck_assert_int_eq(*e, expected_remaining[i]);
   }
   al_free_internal(&al);
 } END_TEST
 
 START_TEST(test_al_remove_all_past_boundary) {
   ArrayList al;
-  al_init(&al);
-  int* es[10];
-  for (int i = 0; i < 10; i++) {
-    int* e = malloc(sizeof(int));
-    *e = i;
-    es[i] = e;
-  }
-  al_add_all(&al, (void**) es, 10);
+  al_init(&al, sizeof(int));
+  int es[10] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+  al_add_all(&al, es, 10);
 
-  int* removed[5] = { NULL };
-  al_remove_all_at(&al, (void**) &removed, 3, 11);
+  int removed[5] = { 0 };
+  al_remove_all_at(&al, removed, 3, 11);
 
   for (int i = 0; i < 5; i++) {
-    ck_assert_ptr_null(removed[i]);
+    ck_assert_int_eq(removed[i], 0);
   }
   int expected_remaining[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
   for (int i = 0; i < 10; i++) {
-    int e = *((int*) al.data[i]);
-    ck_assert_int_eq(e, expected_remaining[i]);
+    int* e = al_get(&al, i);
+    ck_assert_int_eq(*e, expected_remaining[i]);
   }
   al_free_internal(&al);
 } END_TEST
 
 START_TEST(test_al_remove_all_at_invalid_from_to) {
   ArrayList al;
-  al_init(&al);
+  al_init(&al, sizeof(int));
 
-  int* es[10];
-  for (int i = 0; i < 10; i++) {
-    int* e = malloc(sizeof(int));
-    *e = i;
-    es[i] = e;
-  }
-  al_add_all(&al, (void**) es, 10);
+  int es[10] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+  al_add_all(&al, es, 10);
 
-  int* removed[5] = { NULL };
-  al_remove_all_at(&al, (void**) &removed, 8, 3);
+  int removed[5] = { 0 };
+  al_remove_all_at(&al, removed, 8, 3);
 
   for (int i = 0; i < 5; i++) {
-    ck_assert_ptr_null(removed[i]);
+    ck_assert_int_eq(removed[i], 0);
   }
-
   int expected_remaining[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
   for (int i = 0; i < 10; i++) {
-    int e = *((int*) al.data[i]);
-    ck_assert_int_eq(e, expected_remaining[i]);
+    int* e = al_get(&al, i);
+    ck_assert_int_eq(*e, expected_remaining[i]);
   }
   al_free_internal(&al);
 } END_TEST

--- a/test/model/arraylist_test.c
+++ b/test/model/arraylist_test.c
@@ -58,14 +58,15 @@ START_TEST(test_al_add_all_at_expand) {
     al_add(&al, &i);
   }
 
-  // insert 20 zeros at index 10.
-  int es[20] = { 0 };
-  al_add_all_at(&al, es, 20, 10);
+  // insert 30 zeros at index 10.
+  int es[30] = { 0 };
+  al_add_all_at(&al, es, 30, 10);
 
   ck_assert_int_eq(al.cap, 64);
-  ck_assert_int_eq(al.size, 40);
+  ck_assert_int_eq(al.size, 50);
   int expected[] = {
      0,  1,  2,  3,  4,  5,  6,  7,  8,  9, \
+     0,  0,  0,  0,  0,  0,  0,  0,  0,  0, \
      0,  0,  0,  0,  0,  0,  0,  0,  0,  0, \
      0,  0,  0,  0,  0,  0,  0,  0,  0,  0, \
     10, 11, 12, 13, 14, 15, 16, 17, 18, 19  \

--- a/test/model/crdt/sequence_test.c
+++ b/test/model/crdt/sequence_test.c
@@ -484,13 +484,13 @@ Suite* sequence_suite(void) {
   tcase_add_test(tc_find, test_seq_iindex_of_odd);
   tcase_add_test(tc_find, test_seq_iindex_of_even_non_existent);
   tcase_add_test(tc_find, test_seq_iindex_of_odd_non_existent);
-  suite_add_tcase(s, tc_find);
+  // suite_add_tcase(s, tc_find);
 
   tcase_add_test(tc_insert_delete, test_seq_insert);
   tcase_add_test(tc_insert_delete, test_seq_delete);
   tcase_add_test(tc_insert_delete, test_seq_remote_insert);
   tcase_add_test(tc_insert_delete, test_seq_remote_delete);
-  suite_add_tcase(s, tc_insert_delete);
+  // suite_add_tcase(s, tc_insert_delete);
 
   return s;
 }

--- a/test/model/crdt/sequence_test.c
+++ b/test/model/crdt/sequence_test.c
@@ -142,7 +142,7 @@ START_TEST(test_seq_gen_guid_between_same_key_different_uid) {
 START_TEST(test_seq_iindex_of_even) {
   Sequence* s = seq_new();
   // remove header and trailer elements for the purpose of this test.
-  al_init(&s->elements);
+  al_init(&s->elements, sizeof(Element));
   // insert 8 Element pointers.
   for (int i = 0; i < 8; i++) {
     Element* e = element_new();
@@ -154,7 +154,7 @@ START_TEST(test_seq_iindex_of_even) {
       .keys = keys_from_tokens(3, 0, 0, i),
     };
     *((int*) e->value) = i;
-    al_add(&s->elements, (void*) e);
+    al_add(&s->elements, e);
   }
 
   // somewhere in the middle.
@@ -189,7 +189,7 @@ START_TEST(test_seq_iindex_of_even) {
 START_TEST(test_seq_iindex_of_odd) {
   Sequence* s = seq_new();
   // remove header and trailer elements for the purpose of this test.
-  al_init(&s->elements);
+  al_init(&s->elements, sizeof(Element));
   // insert 7 Element pointers.
   for (int i = 0; i < 7; i++) {
     Element* e = element_new();
@@ -201,7 +201,7 @@ START_TEST(test_seq_iindex_of_odd) {
       .keys = keys_from_tokens(3, 0, 0, i),
     };
     *((int*) e->value) = i;
-    al_add(&s->elements, (void*) e);
+    al_add(&s->elements, e);
   }
 
   // somewhere in the middle.
@@ -236,7 +236,7 @@ START_TEST(test_seq_iindex_of_odd) {
 START_TEST(test_seq_iindex_of_even_non_existent) {
   Sequence* s = seq_new();
   // remove header and trailer elements for the purpose of this test.
-  al_init(&s->elements);
+  al_init(&s->elements, sizeof(Element));
   // insert 8 Element pointers with even key tokens.
   for (int i = 0; i < 8; i++) {
     Element* e = element_new();
@@ -248,7 +248,7 @@ START_TEST(test_seq_iindex_of_even_non_existent) {
       .keys = keys_from_tokens(4, 0, 0, 0, i * 2),
     };
     *((int*) e->value) = i;
-    al_add(&s->elements, (void*) e);
+    al_add(&s->elements, e);
   }
 
   // somewhere in the middle.
@@ -287,7 +287,7 @@ START_TEST(test_seq_iindex_of_even_non_existent) {
 START_TEST(test_seq_iindex_of_odd_non_existent) {
   Sequence* s = seq_new();
   // remove header and trailer elements for the purpose of this test.
-  al_init(&s->elements);
+  al_init(&s->elements, sizeof(Element));
   // insert 7 Element pointers with even key tokens.
   for (int i = 0; i < 7; i++) {
     Element* e = element_new();
@@ -299,7 +299,7 @@ START_TEST(test_seq_iindex_of_odd_non_existent) {
       .keys = keys_from_tokens(4, 0, 0, 0, i * 2),
     };
     *((int*) e->value) = i;
-    al_add(&s->elements, (void*) e);
+    al_add(&s->elements, e);
   }
 
   // somewhere in the middle.

--- a/test/model/crdt/sequence_test.c
+++ b/test/model/crdt/sequence_test.c
@@ -145,16 +145,17 @@ START_TEST(test_seq_iindex_of_even) {
   al_init(&s->elements, sizeof(Element));
   // insert 8 Element pointers.
   for (int i = 0; i < 8; i++) {
-    Element* e = element_new();
-    e->value = malloc(sizeof(int));
     // give all elements a simple incremental guid.
     // at depth 3, all 8 elements can fit under one node.
-    e->id = (Guid) {
-      .depth = 3,
-      .keys = keys_from_tokens(3, 0, 0, i),
+    Element e = {
+      .id = (Guid) {
+        .depth = 3,
+        .keys = keys_from_tokens(3, 0, 0, i),
+      },
+      .value = malloc(sizeof(int)),
     };
-    *((int*) e->value) = i;
-    al_add(&s->elements, e);
+    *(int*) e.value = i;
+    al_add(&s->elements, &e);
   }
 
   // somewhere in the middle.
@@ -192,16 +193,15 @@ START_TEST(test_seq_iindex_of_odd) {
   al_init(&s->elements, sizeof(Element));
   // insert 7 Element pointers.
   for (int i = 0; i < 7; i++) {
-    Element* e = element_new();
-    e->value = malloc(sizeof(int));
-    // give all elements a simple incremental guid.
-    // at depth 3, all 8 elements can fit under one node.
-    e->id = (Guid) {
-      .depth = 3,
-      .keys = keys_from_tokens(3, 0, 0, i),
+    Element e = {
+      .id = (Guid) {
+        .depth = 3,
+        .keys = keys_from_tokens(3, 0, 0, i),
+      },
+      .value = malloc(sizeof(int)),
     };
-    *((int*) e->value) = i;
-    al_add(&s->elements, e);
+    *(int*) e.value = i;
+    al_add(&s->elements, &e);
   }
 
   // somewhere in the middle.
@@ -239,16 +239,17 @@ START_TEST(test_seq_iindex_of_even_non_existent) {
   al_init(&s->elements, sizeof(Element));
   // insert 8 Element pointers with even key tokens.
   for (int i = 0; i < 8; i++) {
-    Element* e = element_new();
-    e->value = malloc(sizeof(int));
     // give all elements a simple incremental guid.
     // at depth 4, there are 16 possible locations.
-    e->id = (Guid) {
-      .depth = 4,
-      .keys = keys_from_tokens(4, 0, 0, 0, i * 2),
+    Element e = {
+      .id = (Guid) {
+        .depth = 4,
+        .keys = keys_from_tokens(4, 0, 0, 0, i * 2),
+      },
+      .value = malloc(sizeof(int)),
     };
-    *((int*) e->value) = i;
-    al_add(&s->elements, e);
+    *(int*) e.value = i;
+    al_add(&s->elements, &e);
   }
 
   // somewhere in the middle.
@@ -290,16 +291,17 @@ START_TEST(test_seq_iindex_of_odd_non_existent) {
   al_init(&s->elements, sizeof(Element));
   // insert 7 Element pointers with even key tokens.
   for (int i = 0; i < 7; i++) {
-    Element* e = element_new();
-    e->value = malloc(sizeof(int));
     // give all elements a simple incremental guid.
     // at depth 4, there are 16 possible locations.
-    e->id = (Guid) {
-      .depth = 4,
-      .keys = keys_from_tokens(4, 0, 0, 0, i * 2),
+    Element e = {
+      .id = (Guid) {
+        .depth = 4,
+        .keys = keys_from_tokens(4, 0, 0, 0, i * 2),
+      },
+      .value = malloc(sizeof(int)),
     };
-    *((int*) e->value) = i;
-    al_add(&s->elements, e);
+    *(int*) e.value = i;
+    al_add(&s->elements, &e);
   }
 
   // somewhere in the middle.
@@ -352,8 +354,8 @@ START_TEST(test_seq_insert) {
 
   // check that all elements are sorted by Guid.
   for (int i = 1; i < s->elements.size; i++) {
-    Element* prev = ((Element**) s->elements.data)[i - 1];
-    Element* curr = ((Element**) s->elements.data)[i];
+    Element* prev = al_get(&s->elements, i - 1);
+    Element* curr = al_get(&s->elements, i);
     ck_assert_int_lt(guid_compare(&prev->id, &curr->id), 0);
   }
 }
@@ -382,8 +384,8 @@ START_TEST(test_seq_delete) {
 
   // check that all elements are sorted by Guid.
   for (int i = 1; i < s->elements.size; i++) {
-    Element* prev = ((Element**) s->elements.data)[i - 1];
-    Element* curr = ((Element**) s->elements.data)[i];
+    Element* prev = al_get(&s->elements, i - 1);
+    Element* curr = al_get(&s->elements, i);
     ck_assert_int_lt(guid_compare(&prev->id, &curr->id), 0);
   }
 }
@@ -392,18 +394,18 @@ START_TEST(test_seq_remote_insert) {
   Sequence* s = seq_new();
   char* data = "this is a string";
   int n = strlen(data);
-  Element* remote_inserts[n];
+  Element remote_inserts[n];
   for (int i = 0; i < n; i++) {
-    remote_inserts[i] = seq_insert(s, data + i, i);
+    seq_insert_save(s, data + i, i, &remote_inserts[i]);
   }
 
   Sequence* s2 = seq_new();
   // insert remote elements twice.
   for (int i = 0; i < n; i++) {
-    seq_remote_insert(s2, remote_inserts[i]);
+    seq_remote_insert(s2, &remote_inserts[i]);
   }
   for (int i = 0; i < n; i++) {
-    seq_remote_insert(s2, remote_inserts[i]);
+    seq_remote_insert(s2, &remote_inserts[i]);
   }
 
   // check that all elements are stored properly.
@@ -415,8 +417,8 @@ START_TEST(test_seq_remote_insert) {
 
   // check that all elements are sorted by Guid.
   for (int i = 1; i < s2->elements.size; i++) {
-    Element* prev = ((Element**) s2->elements.data)[i - 1];
-    Element* curr = ((Element**) s2->elements.data)[i];
+    Element* prev = al_get(&s->elements, i - 1);
+    Element* curr = al_get(&s->elements, i);
     ck_assert_int_lt(guid_compare(&prev->id, &curr->id), 0);
   }
 }
@@ -428,18 +430,20 @@ START_TEST(test_seq_remote_delete) {
   char* data = "this is a string";
   int n = strlen(data);
   for (int i = 0; i < n; i++) {
-    seq_remote_insert(s2, seq_insert(s, data + i, i));
+    Element buf;
+    seq_insert_save(s, data + i, i, &buf);
+    seq_remote_insert(s2, &buf);
   }
 
-  Element* remote_deletes[3];
+  Element remote_deletes[3];
   // delete 'h', then delete 'is'
-  remote_deletes[0] = seq_delete(s, 1);
-  remote_deletes[1] = seq_delete(s, 4);
-  remote_deletes[2] = seq_delete(s, 4);
+  seq_delete_save(s, 1, &remote_deletes[0]);
+  seq_delete_save(s, 4, &remote_deletes[1]);
+  seq_delete_save(s, 4, &remote_deletes[2]);
 
   // apply remote deletes not in order.
   for (int i = 2; i >= 0; i--) {
-    seq_remote_delete(s2, remote_deletes[i]);
+    seq_remote_delete(s2, &remote_deletes[i]);
   }
 
   char* expected = "tis  a string";
@@ -453,8 +457,8 @@ START_TEST(test_seq_remote_delete) {
 
   // check that all elements are sorted by Guid.
   for (int i = 1; i < s2->elements.size; i++) {
-    Element* prev = ((Element**) s2->elements.data)[i - 1];
-    Element* curr = ((Element**) s2->elements.data)[i];
+    Element* prev = al_get(&s->elements, i - 1);
+    Element* curr = al_get(&s->elements, i);
     ck_assert_int_lt(guid_compare(&prev->id, &curr->id), 0);
   }
 }
@@ -484,13 +488,13 @@ Suite* sequence_suite(void) {
   tcase_add_test(tc_find, test_seq_iindex_of_odd);
   tcase_add_test(tc_find, test_seq_iindex_of_even_non_existent);
   tcase_add_test(tc_find, test_seq_iindex_of_odd_non_existent);
-  // suite_add_tcase(s, tc_find);
+  suite_add_tcase(s, tc_find);
 
   tcase_add_test(tc_insert_delete, test_seq_insert);
   tcase_add_test(tc_insert_delete, test_seq_delete);
   tcase_add_test(tc_insert_delete, test_seq_remote_insert);
   tcase_add_test(tc_insert_delete, test_seq_remote_delete);
-  // suite_add_tcase(s, tc_insert_delete);
+  suite_add_tcase(s, tc_insert_delete);
 
   return s;
 }


### PR DESCRIPTION
Instead of storing an array of pointers to the objects being stored, the ArrayList now allocates the physical memory space required to sequentially store all elements of the ArrayList.

The ArrayList is stored as an array of `char` data. When initializing an ArrayList, the `size_t` of each element must be specified, which determines the offset at which the elements have to be stored. Then, to retrieve elements is as simple as scaling the search index by the element size.

While this means that `ArrayList.data` is no longer type and memory safe, as long as the proper interface methods are used, this will simplify memory management of each element.