### PR TITLE
Use a union of either long or pointer data for Element

### DIFF
--- a/src/model/crdt/element.c
+++ b/src/model/crdt/element.c
@@ -4,7 +4,7 @@
 void element_init(Element* e) {
   guid_init(&e->id);
   e->version = 0;
-  e->value = NULL;
+  e->data.ptr = NULL;
 }
 
 Element* element_new(void) {
@@ -14,12 +14,18 @@ Element* element_new(void) {
 }
 
 void element_free(Element** e) {
-  element_free_internal(*e);
   free(*e);
   *e = NULL;
 }
 
-void element_free_internal(Element* e) {
-  free(e->value);
+void element_free_ptr(Element** e) {
+  element_free_internal_ptr(*e);
+  free(*e);
+  *e = NULL;
+}
+
+void element_free_internal_ptr(Element* e) {
+  free(e->data.ptr);
+  e->data.ptr = NULL;
 }
 

--- a/src/model/crdt/element.h
+++ b/src/model/crdt/element.h
@@ -5,7 +5,7 @@
 #include "guid.h"
 
 typedef union {
-  char value;
+  long value;
   void* ptr;
 } EData;
 

--- a/src/model/crdt/element.h
+++ b/src/model/crdt/element.h
@@ -4,16 +4,22 @@
 #include <stdlib.h>
 #include "guid.h"
 
+typedef union {
+  char value;
+  void* ptr;
+} EData;
+
 typedef struct {
   Guid id;
   unsigned int version;
-  void* value;
+  EData data;
 } Element;
 
 void element_init(Element* e);
 Element* element_new(void);
 void element_free(Element** e);
-void element_free_internal(Element* e);
+void element_free_ptr(Element** e);
+void element_free_internal_ptr(Element* e);
 
 #endif
 

--- a/src/model/crdt/sequence.c
+++ b/src/model/crdt/sequence.c
@@ -193,15 +193,17 @@ Element* seq_get_element(Sequence* s, unsigned int index) {
   return al_get(&s->elements, index + 1);
 }
 
-bool _seq_insert(Sequence* s, void* to_insert, unsigned int index, Element* buf) {
+bool _seq_insert(Sequence* s, void* insert_ptr, char insert_val, unsigned int index, Element* buf) {
   if (index < 0 || index > seq_size(s)) {
     return false;
   }
   s->version++;
-  Element new = {
-    .version = s->version,
-    .value = to_insert,
-  };
+  Element new = { .version = s->version };
+  if (insert_ptr == NULL) {
+    new.data.value = insert_val;
+  } else {
+    new.data.ptr = insert_ptr;
+  }
   // account for header index.
   seq_gen_guid_at(s, &new.id, index + 1);
   al_add_at(&s->elements, &new, index + 1);
@@ -212,11 +214,19 @@ bool _seq_insert(Sequence* s, void* to_insert, unsigned int index, Element* buf)
 }
 
 bool seq_insert(Sequence* s, void* to_insert, unsigned int index) {
-  return _seq_insert(s, to_insert, index, NULL);
+  return _seq_insert(s, to_insert, 0, index, NULL);
 }
 
 bool seq_insert_save(Sequence* s, void* to_insert, unsigned int index, Element* buf) {
-  return _seq_insert(s, to_insert, index, buf);
+  return _seq_insert(s, to_insert, 0, index, buf);
+}
+
+bool seq_insert_value(Sequence* s, char to_insert, unsigned int index) {
+  return _seq_insert(s, NULL, to_insert, index, NULL);
+}
+
+bool seq_insert_value_save(Sequence* s, char to_insert, unsigned int index, Element* buf) {
+  return _seq_insert(s, NULL, to_insert, index, buf);
 }
 
 bool _seq_delete(Sequence* s, unsigned int index, Element* buf) {

--- a/src/model/crdt/sequence.h
+++ b/src/model/crdt/sequence.h
@@ -24,6 +24,8 @@ unsigned int seq_size(Sequence* s);
 Element* seq_get_element(Sequence* s, unsigned int index);
 bool seq_insert(Sequence* s, void* to_insert, unsigned int index);
 bool seq_insert_save(Sequence* s, void* to_insert, unsigned int index, Element* buf);
+bool seq_insert_value(Sequence* s, char to_insert, unsigned int index);
+bool seq_insert_value_save(Sequence* s, char to_insert, unsigned int index, Element* buf);
 bool seq_delete(Sequence* s, unsigned int index);
 bool seq_delete_save(Sequence* s, unsigned int index, Element* buf);
 bool seq_remote_insert(Sequence* s, Element* to_insert);


### PR DESCRIPTION
`long` and `void*` have the same size, therefore there are minimal downsides to using a union of the two for the `Element` structure.

The main benefit of storing the value itself on the Element, rather than a pointer to the value, is that it allows for much faster reading of values off the array of `Element` objects.

The previous performance enhancement to `ArrayList` allows elements to be stored as a series of bytes in a continuous block of memory, instead of as an array of pointers to each element.

Therefore, it should be much faster to read the values of every Element, as we can have constant stride over the memory occupied by `ArrayList`.